### PR TITLE
if PostgreSQL returns an error check that matches that of relation not found and makes the appropriate return

### DIFF
--- a/tables_test.go
+++ b/tables_test.go
@@ -159,8 +159,8 @@ func TestInsertInTables(t *testing.T) {
 		{"execute insert in a table with jsonb field", "/prest/public/testjson", mJSON, http.StatusOK},
 		{"execute insert in a table without custom where clause", "/prest/public/test", m, http.StatusOK},
 		{"execute insert in a table with invalid database", "/0prest/public/test", m, http.StatusBadRequest},
-		{"execute insert in a table with invalid schema", "/prest/0public/test", m, http.StatusBadRequest},
-		{"execute insert in a table with invalid table", "/prest/public/0test", m, http.StatusBadRequest},
+		{"execute insert in a table with invalid schema", "/prest/0public/test", m, http.StatusNotFound},
+		{"execute insert in a table with invalid table", "/prest/public/0test", m, http.StatusNotFound},
 		{"execute insert in a table with invalid body", "/prest/public/test", nil, http.StatusBadRequest},
 	}
 


### PR DESCRIPTION
issue #196
https://github.com/prest/prest/issues/196
I particularly did not like the solution of using a regex and checking the PostgreSQL error return, but since the database does not return an error object I believe this is the only way.

If there is another solution I'd like to hear about it.