### PR TITLE
Revised batch insert

### DIFF
--- a/tables.go
+++ b/tables.go
@@ -244,16 +244,12 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 	if strings.ToLower(method) != "copy" {
 		sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
 		sc = config.PrestConf.Adapter.BatchInsertValues(sql, values...)
-		if sc.Err() != nil {
-			http.Error(w, sc.Err().Error(), http.StatusBadRequest)
-			return
-		}
 	} else {
 		sc = config.PrestConf.Adapter.BatchInsertCopy(table, strings.Split(names, ","), values)
-		if sc.Err() != nil {
-			http.Error(w, sc.Err().Error(), http.StatusBadRequest)
-			return
-		}
+	}
+	if sc.Err() != nil {
+		http.Error(w, sc.Err().Error(), http.StatusBadRequest)
+		return
 	}
 	w.WriteHeader(http.StatusCreated)
 	w.Write(sc.Bytes())

--- a/tables.go
+++ b/tables.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gorilla/mux"
+	"github.com/prest/adapters"
 	"github.com/prest/config"
 )
 
@@ -238,13 +239,23 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-
-	sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
-	sc := config.PrestConf.Adapter.BatchInsert(sql, values...)
-	if sc.Err() != nil {
-		http.Error(w, sc.Err().Error(), http.StatusBadRequest)
-		return
+	var sc adapters.Scanner
+	method := r.Header.Get("Prest-Batch-Method")
+	if strings.ToLower(method) != "copy" {
+		sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
+		sc = config.PrestConf.Adapter.BatchInsertValues(sql, values...)
+		if sc.Err() != nil {
+			http.Error(w, sc.Err().Error(), http.StatusBadRequest)
+			return
+		}
+	} else {
+		sc = config.PrestConf.Adapter.BatchInsertCopy(database, schema, table, strings.Split(names, ","), values)
+		if sc.Err() != nil {
+			http.Error(w, sc.Err().Error(), http.StatusBadRequest)
+			return
+		}
 	}
+	w.WriteHeader(http.StatusCreated)
 	w.Write(sc.Bytes())
 }
 

--- a/tables.go
+++ b/tables.go
@@ -245,7 +245,7 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 		sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
 		sc = config.PrestConf.Adapter.BatchInsertValues(sql, values...)
 	} else {
-		sc = config.PrestConf.Adapter.BatchInsertCopy(database, schema, table, strings.Split(names, ","), values)
+		sc = config.PrestConf.Adapter.BatchInsertCopy(database, schema, table, strings.Split(names, ","), values...)
 	}
 	if err = sc.Err(); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)

--- a/tables.go
+++ b/tables.go
@@ -245,10 +245,10 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 		sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
 		sc = config.PrestConf.Adapter.BatchInsertValues(sql, values...)
 	} else {
-		sc = config.PrestConf.Adapter.BatchInsertCopy(table, strings.Split(names, ","), values)
+		sc = config.PrestConf.Adapter.BatchInsertCopy(database, schema, table, strings.Split(names, ","), values)
 	}
-	if sc.Err() != nil {
-		http.Error(w, sc.Err().Error(), http.StatusBadRequest)
+	if err = sc.Err(); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
 	w.WriteHeader(http.StatusCreated)

--- a/tables.go
+++ b/tables.go
@@ -240,7 +240,7 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
-	sc := config.PrestConf.Adapter.BatchInsert(sql, values)
+	sc := config.PrestConf.Adapter.BatchInsert(sql, values...)
 	if sc.Err() != nil {
 		http.Error(w, sc.Err().Error(), http.StatusBadRequest)
 		return

--- a/tables.go
+++ b/tables.go
@@ -249,7 +249,7 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		sc = config.PrestConf.Adapter.BatchInsertCopy(database, schema, table, strings.Split(names, ","), values)
+		sc = config.PrestConf.Adapter.BatchInsertCopy(table, strings.Split(names, ","), values)
 		if sc.Err() != nil {
 			http.Error(w, sc.Err().Error(), http.StatusBadRequest)
 			return

--- a/tables.go
+++ b/tables.go
@@ -239,7 +239,7 @@ func BatchInsertInTables(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	sql := config.PrestConf.Adapter.BatchInsertSQL(database, schema, table, names, placeholders[0])
+	sql := config.PrestConf.Adapter.InsertSQL(database, schema, table, names, placeholders)
 	sc := config.PrestConf.Adapter.BatchInsert(sql, values)
 	if sc.Err() != nil {
 		http.Error(w, sc.Err().Error(), http.StatusBadRequest)

--- a/tables_test.go
+++ b/tables_test.go
@@ -252,7 +252,7 @@ func TestUpdateFromTable(t *testing.T) {
 	server := httptest.NewServer(router)
 	defer server.Close()
 
-	m := make(map[string]interface{}, 0)
+	m := make(map[string]interface{})
 	m["name"] = "prest"
 
 	var testCases = []struct {

--- a/tables_test.go
+++ b/tables_test.go
@@ -1,6 +1,9 @@
 package controllers
 
 import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -204,19 +207,47 @@ func TestBatchInsertInTables(t *testing.T) {
 		url         string
 		request     []map[string]interface{}
 		status      int
+		isCopy      bool
 	}{
-		{"execute insert in a table with array field", "/batch/prest/public/testarray", mARRAY, http.StatusOK},
-		{"execute insert in a table with jsonb field", "/batch/prest/public/testjson", mJSON, http.StatusOK},
-		{"execute insert in a table without custom where clause", "/batch/prest/public/test", m, http.StatusOK},
-		{"execute insert in a table with invalid database", "/batch/0prest/public/test", m, http.StatusBadRequest},
-		{"execute insert in a table with invalid schema", "/batch/prest/0public/test", m, http.StatusBadRequest},
-		{"execute insert in a table with invalid table", "/batch/prest/public/0test", m, http.StatusBadRequest},
-		{"execute insert in a table with invalid body", "/batch/prest/public/test", nil, http.StatusBadRequest},
+		{"execute insert in a table with array field", "/batch/prest/public/testarray", mARRAY, http.StatusCreated, false},
+		{"execute insert in a table with jsonb field", "/batch/prest/public/testjson", mJSON, http.StatusCreated, false},
+		{"execute insert in a table without custom where clause", "/batch/prest/public/test", m, http.StatusCreated, false},
+		{"execute insert in a table with invalid database", "/batch/0prest/public/test", m, http.StatusBadRequest, false},
+		{"execute insert in a table with invalid schema", "/batch/prest/0public/test", m, http.StatusBadRequest, false},
+		{"execute insert in a table with invalid table", "/batch/prest/public/0test", m, http.StatusBadRequest, false},
+		{"execute insert in a table with invalid body", "/batch/prest/public/test", nil, http.StatusBadRequest, false},
+		{"execute insert in a table with array field with copy", "/batch/prest/public/testarray", mARRAY, http.StatusCreated, true},
+		{"execute insert in a table with jsonb field with copy", "/batch/prest/public/testjson", mJSON, http.StatusCreated, true},
 	}
 
 	for _, tc := range testCases {
 		t.Log(tc.description)
-		doRequest(t, server.URL+tc.url, tc.request, "POST", tc.status, "BatchInsertInTables")
+		byt, err := json.Marshal(tc.request)
+		if err != nil {
+			t.Error("error on json marshal", err)
+		}
+		req, err := http.NewRequest(http.MethodPost, server.URL+tc.url, bytes.NewReader(byt))
+		if err != nil {
+			t.Error("error on New Request", err)
+		}
+		if tc.isCopy {
+			req.Header.Set("Prest-Batch-Method", "copy")
+		}
+		client := &http.Client{}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Error("error on Do Request", err)
+		}
+		if resp.StatusCode != tc.status {
+			t.Errorf("expected %d, got: %d", tc.status, resp.StatusCode)
+		}
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			t.Error("error on ioutil ReadAll", err)
+		}
+		if tc.isCopy && len(body) != 0 {
+			t.Errorf("len body is %d", len(body))
+		}
 	}
 }
 

--- a/tables_test.go
+++ b/tables_test.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -246,7 +245,6 @@ func TestBatchInsertInTables(t *testing.T) {
 			if err != nil {
 				t.Error("error on ioutil ReadAll", err)
 			}
-			fmt.Println(">>>>>>>>>", string(body))
 			if tc.isCopy && len(body) != 0 {
 				t.Errorf("len body is %d", len(body))
 			}

--- a/tables_test.go
+++ b/tables_test.go
@@ -222,34 +222,35 @@ func TestBatchInsertInTables(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		t.Log(tc.description)
-		byt, err := json.Marshal(tc.request)
-		if err != nil {
-			t.Error("error on json marshal", err)
-		}
-		req, err := http.NewRequest(http.MethodPost, server.URL+tc.url, bytes.NewReader(byt))
-		if err != nil {
-			t.Error("error on New Request", err)
-		}
-		if tc.isCopy {
-			req.Header.Set("Prest-Batch-Method", "copy")
-		}
-		client := &http.Client{}
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Error("error on Do Request", err)
-		}
-		if resp.StatusCode != tc.status {
-			t.Errorf("expected %d, got: %d", tc.status, resp.StatusCode)
-		}
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			t.Error("error on ioutil ReadAll", err)
-		}
-		fmt.Println(">>>>>>>>>", string(body))
-		if tc.isCopy && len(body) != 0 {
-			t.Errorf("len body is %d", len(body))
-		}
+		t.Run(tc.description, func(t *testing.T) {
+			byt, err := json.Marshal(tc.request)
+			if err != nil {
+				t.Error("error on json marshal", err)
+			}
+			req, err := http.NewRequest(http.MethodPost, server.URL+tc.url, bytes.NewReader(byt))
+			if err != nil {
+				t.Error("error on New Request", err)
+			}
+			if tc.isCopy {
+				req.Header.Set("Prest-Batch-Method", "copy")
+			}
+			client := &http.Client{}
+			resp, err := client.Do(req)
+			if err != nil {
+				t.Error("error on Do Request", err)
+			}
+			if resp.StatusCode != tc.status {
+				t.Errorf("expected %d, got: %d", tc.status, resp.StatusCode)
+			}
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Error("error on ioutil ReadAll", err)
+			}
+			fmt.Println(">>>>>>>>>", string(body))
+			if tc.isCopy && len(body) != 0 {
+				t.Errorf("len body is %d", len(body))
+			}
+		})
 	}
 }
 

--- a/tables_test.go
+++ b/tables_test.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -245,6 +246,7 @@ func TestBatchInsertInTables(t *testing.T) {
 		if err != nil {
 			t.Error("error on ioutil ReadAll", err)
 		}
+		fmt.Println(">>>>>>>>>", string(body))
 		if tc.isCopy && len(body) != 0 {
 			t.Errorf("len body is %d", len(body))
 		}


### PR DESCRIPTION
Improvements on batch insert feature

- returns 201 instead of 200
- use multi-values (`insert into xxx values (xxx), (yyy)`) as default to improve performance
- allow to use insert with copy by header `Prest-Batch-Method`, recommended for large dataset

After all merge's these resources will be documented.

Related to https://github.com/prest/prest/issues/295 and **depends on** https://github.com/prest/adapters/pull/42.