### PR TITLE
Set default database on Custom Query

### DIFF
--- a/sql.go
+++ b/sql.go
@@ -10,6 +10,7 @@ import (
 
 // ExecuteScriptQuery is a function to execute and return result of script query
 func ExecuteScriptQuery(rq *http.Request, queriesPath string, script string) ([]byte, error) {
+	config.PrestConf.Adapter.SetDatabase(config.PrestConf.PGDatabase)
 	sqlPath, err := config.PrestConf.Adapter.GetScript(rq.Method, queriesPath, script)
 	if err != nil {
 		err = fmt.Errorf("could not get script %s/%s, %+v", queriesPath, script, err)


### PR DESCRIPTION
When making a request in which the name of the database is informed, this name is set in the connection by adapter.SetDatabase ().
Example: https://github.com/prest/controllers/blob/master/tables.go#L106

So it is necessary to run a Custom Query, set the default bank again.

Ref: https://github.com/prest/prest/issues/343#issuecomment-503271905